### PR TITLE
Update opentelekomcloud-infra/crutch-house dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,9 @@ replace (
 require (
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/huaweicloud/golangsdk v0.0.0-20200414012957-3b8a408c2816
-	github.com/opentelekomcloud-infra/crutch-house v0.1.1-0.20200609072713-cf79f34d7070
-	github.com/pkg/errors v0.8.1
+	github.com/opentelekomcloud-infra/crutch-house v0.2.1
 	github.com/rancher/kontainer-engine v0.0.4-dev.0.20200406202044-bf3f55d3710a
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.5.1
-	k8s.io/api v0.18.0
-	k8s.io/apimachinery v0.18.0
 	k8s.io/client-go v12.0.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -539,8 +539,8 @@ github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQ
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/openshift/prom-label-proxy v0.1.1-0.20191016113035-b8153a7f39f1/go.mod h1:p5MuxzsYP1JPsNGwtjtcgRHHlGziCJJfztff91nNixw=
-github.com/opentelekomcloud-infra/crutch-house v0.1.1-0.20200609072713-cf79f34d7070 h1:Oz1TRUiRI/xH+dU8B36AZamJqB9kpEnaDBXBZEvPKHI=
-github.com/opentelekomcloud-infra/crutch-house v0.1.1-0.20200609072713-cf79f34d7070/go.mod h1:V1ievzAnkZT7QQlkGt4azI86WWNpgmD7jQ7eDZG4pus=
+github.com/opentelekomcloud-infra/crutch-house v0.2.1 h1:uaEo5z+3yHBjv4wluKDYo8Rs/sE4yT5U9rPGZ5kKY5w=
+github.com/opentelekomcloud-infra/crutch-house v0.2.1/go.mod h1:V1ievzAnkZT7QQlkGt4azI86WWNpgmD7jQ7eDZG4pus=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=


### PR DESCRIPTION
Required to work with the newer version of CCE