### PR TITLE
Fix cluster creation

### DIFF
--- a/opentelekomcloud/driver.go
+++ b/opentelekomcloud/driver.go
@@ -626,6 +626,10 @@ func cleanupManagedResources(client services.Client, state *clusterState) error 
 
 func (d *CCEDriver) Create(_ context.Context, opts *types.DriverOptions, info *types.ClusterInfo) (*types.ClusterInfo, error) {
 	logrus.Info("Start creating cluster")
+	if info == nil {
+		logrus.Debug("Info is nil, initialize info")
+		info = &types.ClusterInfo{}
+	}
 	logrus.Debug("Get state from opts")
 	state, err := optsToState(opts)
 	if err != nil {

--- a/opentelekomcloud/driver_test.go
+++ b/opentelekomcloud/driver_test.go
@@ -167,7 +167,7 @@ func TestDriver_ClusterWorkflow(t *testing.T) {
 	}()
 
 	driver := NewDriver()
-	info, err := driver.Create(ctx, driverOptions, &types.ClusterInfo{})
+	info, err := driver.Create(ctx, driverOptions, nil)
 	require.NoError(t, err)
 	t.Log("Cluster created")
 


### PR DESCRIPTION
Add initialization of `info` in `Create` in case it is `nil`

Fix #37